### PR TITLE
[DEV-30252] Add disable_ssl option

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -389,12 +389,13 @@ _mysql_ConnectionObject_Initialize(
          *db = NULL, *unix_socket = NULL;
     unsigned int port = 0;
     unsigned int client_flag = 0;
+    unsigned int disable_ssl;
     static char *kwlist[] = { "host", "user", "passwd", "db", "port",
                   "unix_socket", "conv",
                   "connect_timeout", "compress",
                   "named_pipe", "init_command",
                   "read_default_file", "read_default_group",
-                  "client_flag", "ssl",
+                  "client_flag", "ssl", "disable_ssl",
                   "local_infile",
                   "read_timeout", "write_timeout",
                   NULL } ;
@@ -410,7 +411,7 @@ _mysql_ConnectionObject_Initialize(
     self->open = 0;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
-                "|ssssisOiiisssiOiii:connect",
+                "|ssssisOiiisssiOiiii:connect",
                 kwlist,
                 &host, &user, &passwd, &db,
                 &port, &unix_socket, &conv,
@@ -419,6 +420,7 @@ _mysql_ConnectionObject_Initialize(
                 &init_command, &read_default_file,
                 &read_default_group,
                 &client_flag, &ssl,
+                &disable_ssl,
                 &local_infile,
                 &read_timeout,
                 &write_timeout
@@ -477,6 +479,13 @@ _mysql_ConnectionObject_Initialize(
 
     if (local_infile != -1)
         mysql_options(&(self->connection), MYSQL_OPT_LOCAL_INFILE, (char *) &local_infile);
+
+    if (disable_ssl) {
+        /* Force the client to disable SSL connections */
+        unsigned int ssl_mode_disabled = SSL_MODE_DISABLED;
+
+        mysql_options(&(self->connection), MYSQL_OPT_SSL_MODE, (char *) &ssl_mode_disabled);
+    }
 
     if (ssl) {
         mysql_ssl_set(&(self->connection), key, cert, ca, capath, cipher);
@@ -568,6 +577,9 @@ read_default_group\n\
 \n\
 client_flag\n\
   client flags from MySQLdb.constants.CLIENT\n\
+\n\
+disable_ssl\n\
+  integer, 1 to disable SSL; 0 otherwise\n\
 \n\
 load_infile\n\
   int, non-zero enables LOAD LOCAL INFILE, zero disables\n\

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -101,6 +101,9 @@ class Connection(_mysql.connection):
         :param bool local_infile:
             enables LOAD LOCAL INFILE; zero disables
 
+        :param bool disable_ssl:
+            sets SSL mode to disabled; zero maintains default SSL mode
+
         :param bool autocommit:
             If False (default), autocommit is disabled.
             If True, autocommit is enabled.
@@ -160,6 +163,8 @@ class Connection(_mysql.connection):
 
         # PEP-249 requires autocommit to be initially off
         autocommit = kwargs2.pop('autocommit', False)
+
+        kwargs2.setdefault('disable_ssl', 0)
 
         super(Connection, self).__init__(*args, **kwargs2)
         self.cursorclass = cursorclass


### PR DESCRIPTION
These changes add a `disable_ssl` option which makes the MYSQL_OPT_SSL_MODE to SSL_MODE_DISABLED (see https://dev.mysql.com/doc/refman/8.0/en/mysql-options.html). This is turned off by default.

I tested these changes by pointing our webapp at this branch and passing the `disable_ssl` option down through the `options` dictionary within the `DATABASES` setting.

With the webapp pointed to this fork WITHOUT passing `disable_ssl`, you can see the version is correct (`1.4.2.post`) and SSL is still enabled as it is by default:
```python
In [1]: from django.db import connections

In [2]: User.objects.first()
Out[2]: <User: philip-kimmey>

In [3]: import MySQLdb

In [4]: MySQLdb.__version__
Out[4]: '1.4.2.post1'

In [5]: dw = connections['default']

In [6]: cursor = dw.create_cursor()

In [7]: cursor.cursor.execute("SHOW STATUS LIKE 'Ssl_cipher';");

In [8]: cursor.cursor.fetchone()
Out[8]: (u'Ssl_cipher', u'DHE-RSA-AES256-SHA') 
```

With the webapp pointed to this fork WITH passing `disable_ssl`, you can see the version is correct (`1.4.2.post`) and SSL is still disabled:
```python
In [1]: from django.db import connections

In [2]: User.objects.first()
Out[2]: <User: philip-kimmey>

In [3]: import MySQLdb

In [4]: MySQLdb.__version__
Out[4]: '1.4.2.post1'

In [5]: dw = connections['default']

In [6]: cursor = dw.create_cursor()

In [7]: cursor.cursor.execute("SHOW STATUS LIKE 'Ssl_cipher';");

In [8]:  cursor.cursor.fetchone()
Out[8]: (u'Ssl_cipher', u'')
```

After merging this change I will open a PR in the webapp repo to point to the merge commit of this branch into the `rover` branch in this forked repo, and pass down `disable_ssl`.